### PR TITLE
Corrección para que lleve al invoice

### DIFF
--- a/templates/customer_area/clientfacturacion.tpl
+++ b/templates/customer_area/clientfacturacion.tpl
@@ -24,7 +24,7 @@
             {foreach key=num item=order from=$whmcsInvoices}
                 <tr>
                     <td>
-                        <a href="clientarea.php?action=productdetails&amp;id={$order.orderId}">{$order.orderId}</a>
+                        <a href="viewinvoice.php?id={$order.orderId}">{$order.orderId}</a>
                     </td>
                     <td>{$order.orderDate}</td>
                     <td>{$order.invoiceDatePaid}</td>
@@ -74,7 +74,7 @@
                     <td>{$invoice.Folio}</td>
                     <td><span class="hidden">{$invoice.FechaTimbrado}</span>{$invoice.FechaTimbrado}</td>
                     <td>{$invoice.Receptor}</td>
-                    <td><a href="clientarea.php?action=productdetails&amp;id={$invoice.NumOrder}">{$invoice.NumOrder}</a></td>
+                    <td><a href="viewinvoice.php?id={$invoice.NumOrder}">{$invoice.NumOrder}</a></td>
                     <td>${$invoice.Total|number_format:2:".":","}</td>
                     <td><span class="label status status-{if $invoice.Status eq 'enviada'}paid{else}cancelled{/if}">{$invoice.Status}</span></td>
                     <td class="responsive-edit-button">


### PR DESCRIPTION
Hola, no se si este sea el funcionamiento esperado, pero en el archivo: [clientfacturacion.tpl](https://github.com/FacturaPuntoCom/WHMCS33/blob/master/templates/customer_area/clientfacturacion.tpl), el enlace que te lleva al invoice es incorrecto:
`<a href="clientarea.php?action=productdetails&amp;id={$order.orderId}">{$order.orderId}</a>`
Esto produce un error (mínimo en el caso de dominios que no se ven desde productdetails, si nó domaindetails) por que no te lleva al invoice como tal, te intenta llevar al producto relacionándolo al invoice.
Lo correcto seria mandar a viewinvoice.php?id=
Mínimo esto es lo que yo veo reflejado en mi instalación, en caso de que sea incorrecto, favor de hacer caso omiso y notificarme.
Saludos.